### PR TITLE
Fix not to convert max-age to number of milliseconds.

### DIFF
--- a/lib/certs.js
+++ b/lib/certs.js
@@ -72,7 +72,7 @@ KeyManager.prototype.fetchKey = function(keyId, callback, options) {
 KeyManager.prototype.parseCacheControlHeader = function(header) {
   var match = header.match(MAX_AGE_RE);
   if (match) {
-    return match[1];
+    return match[1] * 1000;
   }
   return 0;
 };

--- a/tests/test.certs.js
+++ b/tests/test.certs.js
@@ -59,10 +59,15 @@ describe('KeyManager', function() {
       callback(null, {statusCode: 200, headers: {'cache-control': 'public, max-age=22150, must-revalidate, no-transform'}}, '{"key1": "foo"}');
     });
     
+    var now = Date.now();
     var manager = new KeyManager();    
     manager.fetchKey('key1', function(err, key) {
       should.not.exist(err);
       key.should.equal('foo');
+
+      var expectMinExpiry = now + 22150 * 1000;
+      manager.expiry.should.be.below(expectMinExpiry + 500);
+      manager.expiry.should.not.be.below(expectMinExpiry);
     });
 
     count.should.equal(1);


### PR DESCRIPTION
Refreshing certificates does not work because the expiry is wrong long string.
It is combined current time millis and max-age that remains seconds as string.
So 'shouldFetch' flag does not stand after max-age has elapsed.
