### PR TITLE
Allow non-express based applications to use strategy.

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
  var passport = require('passport'),
     extend = require('xtend'),
     util = require('util'),
@@ -40,7 +40,7 @@ var asArray = function(arrayOrItem) {
 
 /**
  * Memoize API discovery.
- * 
+ *
  * @param {String} api Google API to use
  * @param {String} version Version of API to use
  * @param {Function} callback
@@ -51,20 +51,20 @@ var withApi = async.memoize(function(api, version, callback) {
   return arguments[0] + '.' + arguments[1];
 });
 
-/** 
+/**
  * @callback CompletionCallback
  * @param {String} err Error message if failed
  * @param {Object} user User object
  * @param {Object} info Additional info (typically echo tokens back)
  */
- 
+
 /**
  * @callback GooglePlusStrategyCallback
  * @param {Object} tokens Available tokens. May include access and/or refresh tokens
  * @param {Object} profile User profile
  * @param {CompletionCallback} done Callback to indicate completion of auth
  */
- 
+
 /**
  * Configure the Google+ Sign-In strategy
  *
@@ -94,7 +94,7 @@ var Strategy = function(options, callback) {
 /**
 * Internal state during various phases of exchanging tokens & fetching profiles.
 * Either an authorization code or ID token needs to be set.
-* 
+*
 * @constructor
 * @param {String} authorizationCode Authorization code to exchange, if available
 * @Param {String} idToken ID token to verify, if available
@@ -126,6 +126,19 @@ Strategy.prototype.authenticate = function(req, options) {
     self.success(user, info);
   };
 
+  // Don't depend on express
+  if(!req.param) {
+	  req.param = function(name, defaultValue) {
+	  var params = this.params || {};
+	  var body = this.body || {};
+	  var query = this.query || {};
+	  if (null != params[name] && params.hasOwnProperty(name)) return params[name];
+	  if (null != body[name]) return body[name];
+	  if (null != query[name]) return query[name];
+	  return defaultValue;
+	};
+  }
+
   var context = new Context(req.param('code'), req.param('id_token'), req.param('access_token'));
 
   async.waterfall([
@@ -133,11 +146,11 @@ Strategy.prototype.authenticate = function(req, options) {
     this.exchangeAuthorizationCode.bind(this),
     this.validateIdToken.bind(this),
     this.loadProfile.bind(this)
-    ], function(err, context) { 
+    ], function(err, context) {
       if (err) {
         done(err);
       } else {
-        self.callback(context.credentials, context.profile, done);        
+        self.callback(context.credentials, context.profile, done);
       }
   });
 };
@@ -149,13 +162,13 @@ Strategy.prototype.authenticate = function(req, options) {
  *
  * @param {Context} context Request context to update
  * @param {Function} callback Completion handler
- */ 
+ */
 Strategy.prototype.exchangeAuthorizationCode = function(context, callback) {
   if (context.authorizationCode) {
     var oauth = new OAuth2Client(this.clientId, this.clientSecret, this.redirectUri);
     oauth.getToken(context.authorizationCode, function(err, tokens) {
       context.credentials = tokens;
-      callback(err, context);    
+      callback(err, context);
     });
   } else {
     callback(null, context);
@@ -168,12 +181,12 @@ Strategy.prototype.exchangeAuthorizationCode = function(context, callback) {
  *
  * @param {Context} context Request context to update
  * @param {Function} callback Completion handler
- */ 
+ */
 Strategy.prototype.validateAccessToken = function(context, callback) {
   var self = this;
   if (context.credentials.access_token) {
 	// BEGIN - Temporary workaround for non-resource method bug in API client
-	var url = "https://www.googleapis.com/oauth2/v2/tokeninfo?access_token=" 
+	var url = "https://www.googleapis.com/oauth2/v2/tokeninfo?access_token="
 	  + context.credentials.access_token;
     request.get(url, function(err, res, body) {
       if (res.statusCode == 200) {
@@ -189,7 +202,7 @@ Strategy.prototype.validateAccessToken = function(context, callback) {
         }
       }
       callback(err, context);
-    });	
+    });
     // END - workaround
 /*
     withApi('oauth2', 'v2', function(err, client) {
@@ -222,7 +235,7 @@ Strategy.prototype.validateAccessToken = function(context, callback) {
  *
  * @param {Context} context Request context to update
  * @param {Function} callback Completion handler
- */ 
+ */
 Strategy.prototype.validateIdToken = function(context, callback) {
   var self = this;
   if (context.credentials.id_token) {
@@ -250,7 +263,7 @@ Strategy.prototype.validateIdToken = function(context, callback) {
       });
       jwt.verifyAccessToken(context.credentials.access_token);
       callback(err, context);
-    });	
+    });
   } else {
     callback(null, context);
   }
@@ -262,7 +275,7 @@ Strategy.prototype.validateIdToken = function(context, callback) {
  *
  * @param {Context} context Request context to update
  * @param {Function} callback Completion handler
- */ 
+ */
 Strategy.prototype.loadProfile = function(context, callback) {
   var self = this;
   if (this.fetchProfile) {
@@ -278,7 +291,7 @@ Strategy.prototype.loadProfile = function(context, callback) {
       .withAuthClient(authClient)
       .execute(function(err, data) {
         if(!err) {
-          context.profile = extend(context.profile, data);    
+          context.profile = extend(context.profile, data);
         }
         callback(err, context);
       });


### PR DESCRIPTION
This passport strategy relied on express's `request.param()` function. However, I'm using it in a connect application; no such function exists.

This PR checks to see if there is a `.param` function on the request object, and if not, adds one.
