### PR TITLE
add options noRedirectUri and passReqToCallback

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -88,6 +88,10 @@ var Strategy = function(options, callback) {
   this.redirectUri = options.redirectUri || 'postmessage';
   this.fetchProfile = !options.skipProfile;
   this.authorizedPresenters = options.presenters;
+  this._passReqToCallback = options.passReqToCallback;
+  if(options.noRedirectUri){
+    this.redirectUri = undefined
+  }
 };
 
 
@@ -147,7 +151,12 @@ Strategy.prototype.authenticate = function(req, options) {
       if (err) {
         done(err);
       } else {
-        self.callback(context.credentials, context.profile, done);
+        if (self._passReqToCallback) {
+          self.callback(req, context.credentials, context.profile, done);
+        } else {
+          self.callback(context.credentials, context.profile, done);
+        }
+        
       }
   });
 };


### PR DESCRIPTION
Hi, 
For a mobile to server workflow, the redirectUri should be blank.  I've added an option for that plus another option 'passReqToCallback' which is a commonly used option to pass to req object to the callback. Can you please merge this?
