### PR TITLE
Expose openid_id for migration purposes

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -194,6 +194,7 @@ Strategy.prototype.validateAccessToken = function(context, callback) {
         } else {
           context.profile = extend(context.profile, {
             id: data.user_id,
+            openid_id: data.openid_id,
             email: data.email,
             email_verified: data.verified_email
           });
@@ -236,6 +237,7 @@ Strategy.prototype.validateIdToken = function(context, callback) {
       }
       context.profile = extend(context.profile, {
         id: jwt.payload.sub,
+        openid_id: jwt.payload.openid_id,
         email: jwt.payload.email,
         email_verified: jwt.payload.email_verified || false
       });


### PR DESCRIPTION
For those of us who started with Google OpenID auth, we need a way to migrate users from that to G+. Google recommends sending the OpenID Realm on our button, then catching the openid_id value that will be sent back to our server with the tokens. But currently, this module will not expose that value.

This is a very simple PR to expose that value for migration purposes.
