### PR TITLE
Added support for overriding the redirectUri at runtime.

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -144,7 +144,7 @@ Strategy.prototype.authenticate = function(req, options) {
 
   async.waterfall([
     this.validateAccessToken.bind(this, context),
-    this.exchangeAuthorizationCode.bind(this),
+    this.exchangeAuthorizationCode.bind(this, options),
     this.validateIdToken.bind(this),
     this.loadProfile.bind(this)
     ], function(err, context) {
@@ -171,9 +171,9 @@ Strategy.prototype.authenticate = function(req, options) {
  * @param {Context} context Request context to update
  * @param {Function} callback Completion handler
  */
-Strategy.prototype.exchangeAuthorizationCode = function(context, callback) {
+Strategy.prototype.exchangeAuthorizationCode = function(options, context, callback) {
   if (context.authorizationCode) {
-    var oauth = new OAuth2Client(this.clientId, this.clientSecret, this.redirectUri);
+    var oauth = new OAuth2Client(this.clientId, this.clientSecret, options.redirectUri || this.redirectUri);
     oauth.getToken(context.authorizationCode, function(err, tokens) {
       context.credentials = tokens;
       callback(err, context);


### PR DESCRIPTION
Now you can use a dynamic hostname for the redirectUri, like so:

``` javascript
  app.get('/auth/google/callback', function(req, res) {
    var google_redirect_uri = 'http://' + req.get('Host') +
    '/auth/google/callback';
    passport.authenticate('google', { redirectUri:
      google_redirect_uri})(req, res, function(){
          res.redirect('/');
        });
    });
```
