### PR TITLE
Replace HTTP call in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For example, as route middleware in an [Express](http://expressjs.com/)
 application:
 
 ```js
-app.get('/auth/google/callback', passport.authenticate('google'), function(req, res) {
+app.post('/auth/google/callback', passport.authenticate('google'), function(req, res) {
     // Return user back to client
     res.send(req.user);
 });


### PR DESCRIPTION
As indicated by the [callback](https://github.com/sqrrrl/passport-google-plus#handle-the-callback--forward-the-authorization-code) function, the response will be a POST request.

It was pretty depressing to discover this was the reason why I spent 20 minutes debugging.
