### PR TITLE
parameter naming fix.

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -107,7 +107,7 @@ var Context = function(options, authorizationCode, idToken, accessToken) {
   };
   this.now = Date.now();
   this.apiKey = options.apiKey;
-  this.clientId = options.clientId;
+  this.clientId = options.clientID;
   this.clientSecret = options.clientSecret;
   this.redirectUri = options.redirectUri;
   this.fetchProfile = !options.skipProfile;


### PR DESCRIPTION
It's help me with google 'invalid_request' error.
If i tried to change parameter name in my config to 'clientId', passport throw error.
